### PR TITLE
feat(api): decode base64 binary serial (PrimaDonna Soul + modern firmware)

### DIFF
--- a/custom_components/delonghi_coffee/api.py
+++ b/custom_components/delonghi_coffee/api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import contextlib
 import functools
 import json
@@ -208,20 +209,104 @@ class DeLonghiApi:
     # ── Model identification (TranscodeTable) ─────────────────────────
     # Credit: TranscodeTable approach from FrozenGalaxy/PyDeLonghiAPI
 
-    @staticmethod
-    def parse_serial_number(value: str | None) -> dict[str, str] | None:
-        """Parse d270_serialnumber to extract SKU-matching digits.
+    # Binary serial payload: 6 SKU digits + 2 exec alphanum + 2 year + 2 month
+    # + 2 day + 1 letter + 4 production seq = 19 printable ASCII chars.
+    # Framed by 6 bytes of device-specific header and 3 bytes of trailer (CRC).
+    _BINARY_SERIAL_RE = re.compile(
+        rb"(\d{6}[A-Z0-9]{2}\d{6}[A-Z0-9]\d{4})"
+    )
 
-        The serial format is typically: ECAM{model}{suffix}{production_info}
-        e.g. "ECAM45065S12345" or "ECAM61075MB12345"
-        We extract the numeric portion for TranscodeTable matching.
+    @staticmethod
+    def parse_serial_number(value: str | None) -> dict[str, Any] | None:
+        """Parse ``d270_serialnumber`` to extract SKU digits and production info.
+
+        Two known formats are supported:
+
+        1. **Legacy plaintext** — e.g. ``ECAM61075MB12345``. Digit sequences
+           are concatenated for TranscodeTable matching.
+        2. **Binary envelope (base64)** — e.g. ``0BuhDwDNMjE3MDU1...D9pg==``.
+           Decodes to a 6-byte header, a 19-char ASCII payload laid out as
+           ``CCCCCC EE AA MM GG L PPPP`` (codice / esecuzione / anno / mese /
+           giorno / lettera / produzione per De'Longhi service documentation),
+           and a 3-byte trailer (CRC). Exposes year/month/day/execution/
+           production fields alongside SKU digits.
+
+        Returns ``None`` for empty input. Falls back to plaintext regex when
+        base64 decoding fails or the payload structure does not match.
         """
         if not value:
             return None
-        # Extract all digit sequences from the serial
+
+        binary = DeLonghiApi._try_decode_binary_serial(value)
+        if binary is not None:
+            return binary
+
+        # Plaintext fallback — concatenate all digit runs for SKU matching.
         digits = re.findall(r"\d+", value)
-        all_digits = "".join(digits)
-        return {"raw": value, "digits": all_digits}
+        return {
+            "raw": value,
+            "digits": "".join(digits),
+            "format": "plaintext",
+        }
+
+    @staticmethod
+    def _try_decode_binary_serial(value: str) -> dict[str, Any] | None:
+        """Attempt to decode a base64-framed binary serial envelope.
+
+        Returns the structured dict on success, ``None`` if the input is not
+        a well-formed binary envelope (caller falls back to plaintext).
+        """
+        # Base64 payload must be exclusively b64 alphabet (+ padding) and at
+        # least ~28 bytes encoded. Short plaintext ("ECAM...") or noisy
+        # strings ("!!!not_base64!!!") are rejected here before attempting
+        # decode to avoid false positives.
+        if len(value) < 28 or not re.fullmatch(r"[A-Za-z0-9+/]+={0,2}", value):
+            return None
+        try:
+            decoded = base64.b64decode(value, validate=True)
+        except (ValueError, binascii.Error):
+            return None
+
+        match = DeLonghiApi._BINARY_SERIAL_RE.search(decoded)
+        if match is None:
+            return None
+
+        payload = match.group(1).decode("ascii")
+        # Layout: CCCCCC EE AA MM GG L PPPP (6 + 2 + 2 + 2 + 2 + 1 + 4)
+        sku = payload[0:6]
+        execution = payload[6:8]
+        year_suffix = payload[8:10]
+        month = payload[10:12]
+        day = payload[12:14]
+        letter = payload[14:15]
+        production = payload[15:19]
+
+        try:
+            year = 2000 + int(year_suffix)
+            month_int = int(month)
+            day_int = int(day)
+        except ValueError:
+            return None
+
+        if not (1 <= month_int <= 12 and 1 <= day_int <= 31):
+            return None
+
+        return {
+            "raw": value,
+            # Concatenated digits feed downstream TranscodeTable matching; the
+            # execution field is skipped because it may contain letters (e.g.
+            # "ZZ") and the first 6 digits — the SKU/codice — are what the
+            # matcher consumes.
+            "digits": sku + year_suffix + month + day + production,
+            "sku": sku,
+            "execution": execution,
+            "year": year,
+            "month": month_int,
+            "day": day_int,
+            "letter": letter,
+            "production": production,
+            "format": "binary",
+        }
 
     @staticmethod
     def match_transcode_table(

--- a/custom_components/delonghi_coffee/api.py
+++ b/custom_components/delonghi_coffee/api.py
@@ -12,6 +12,7 @@ import re
 import struct
 import threading
 import time
+from datetime import date
 from typing import Any
 
 import requests
@@ -212,9 +213,11 @@ class DeLonghiApi:
     # Binary serial payload: 6 SKU digits + 2 exec alphanum + 2 year + 2 month
     # + 2 day + 1 letter + 4 production seq = 19 printable ASCII chars.
     # Framed by 6 bytes of device-specific header and 3 bytes of trailer (CRC).
-    _BINARY_SERIAL_RE = re.compile(
-        rb"(\d{6}[A-Z0-9]{2}\d{6}[A-Z0-9]\d{4})"
-    )
+    _BINARY_SERIAL_RE = re.compile(rb"(\d{6}[A-Z0-9]{2}\d{6}[A-Z0-9]\d{4})")
+    _BINARY_SERIAL_HEADER_LEN = 6
+    _BINARY_SERIAL_PAYLOAD_LEN = 19
+    _BINARY_SERIAL_TRAILER_LEN = 3
+    _BINARY_SERIAL_FRAME_LEN = _BINARY_SERIAL_HEADER_LEN + _BINARY_SERIAL_PAYLOAD_LEN + _BINARY_SERIAL_TRAILER_LEN
 
     @staticmethod
     def parse_serial_number(value: str | None) -> dict[str, Any] | None:
@@ -267,7 +270,14 @@ class DeLonghiApi:
         except (ValueError, binascii.Error):
             return None
 
-        match = DeLonghiApi._BINARY_SERIAL_RE.search(decoded)
+        # Require the documented frame size (header + payload + trailer) and
+        # only search within the payload slice. This rejects envelopes where
+        # random bytes happen to match the SKU pattern at the wrong offset
+        # (CodeRabbit review on PR #19).
+        if len(decoded) < DeLonghiApi._BINARY_SERIAL_FRAME_LEN:
+            return None
+        payload_slice = decoded[DeLonghiApi._BINARY_SERIAL_HEADER_LEN : -DeLonghiApi._BINARY_SERIAL_TRAILER_LEN]
+        match = DeLonghiApi._BINARY_SERIAL_RE.search(payload_slice)
         if match is None:
             return None
 
@@ -283,13 +293,15 @@ class DeLonghiApi:
 
         try:
             year = 2000 + int(year_suffix)
-            month_int = int(month)
-            day_int = int(day)
+            # Build a real date object to reject calendrically impossible
+            # combinations like 2025-02-31 that pass naive range checks
+            # (CodeRabbit review on PR #19).
+            production_date = date(year, int(month), int(day))
         except ValueError:
             return None
 
-        if not (1 <= month_int <= 12 and 1 <= day_int <= 31):
-            return None
+        month_int = production_date.month
+        day_int = production_date.day
 
         return {
             "raw": value,

--- a/tests/test_coordinator_keepalive.py
+++ b/tests/test_coordinator_keepalive.py
@@ -10,7 +10,13 @@ import logging
 from unittest.mock import MagicMock
 
 from custom_components.delonghi_coffee.api import DeLonghiApiError
+from custom_components.delonghi_coffee.const import MQTT_KEEPALIVE_INTERVAL
 from custom_components.delonghi_coffee.coordinator import DeLonghiCoordinator
+
+# On a fresh CI runner monotonic() can start near zero, so '_last_keepalive = 0'
+# leaves 'now - 0 < MQTT_KEEPALIVE_INTERVAL' and the keepalive branch never
+# runs. Use a negative offset that guarantees eligibility regardless of uptime.
+_KEEPALIVE_FORCE = -MQTT_KEEPALIVE_INTERVAL - 1
 
 
 class _DirectExecutor:
@@ -28,7 +34,7 @@ def _make_coord(api: MagicMock) -> DeLonghiCoordinator:
     coord.hass = hass
     # Force keepalive path (not full refresh) every call.
     coord._last_full_refresh = 1e12  # far in the future so need_full == False
-    coord._last_keepalive = 0  # first call always hits keepalive branch
+    coord._last_keepalive = _KEEPALIVE_FORCE  # first call always hits keepalive branch
     return coord
 
 
@@ -46,7 +52,7 @@ def test_keepalive_failure_counter_increments_and_resets(caplog) -> None:
 
     async def hammer(n: int) -> None:
         for _ in range(n):
-            coord._last_keepalive = 0  # force keepalive eligibility each cycle
+            coord._last_keepalive = _KEEPALIVE_FORCE  # force keepalive eligibility each cycle
             with contextlib.suppress(Exception):  # only care about the counter
                 await coord._async_update_data()
 
@@ -62,7 +68,7 @@ def test_keepalive_failure_counter_increments_and_resets(caplog) -> None:
     # Recovery resets the counter and emits an info line.
     api.ping_connected.side_effect = None
     api.ping_connected.return_value = True
-    coord._last_keepalive = 0
+    coord._last_keepalive = _KEEPALIVE_FORCE
     asyncio.run(coord._async_update_data())
     assert coord._keepalive_failures == 0, "successful keepalive must reset the counter"
 
@@ -79,7 +85,7 @@ def test_keepalive_error_escalates_at_multiples_of_five(caplog) -> None:
 
     async def hammer(n: int) -> None:
         for _ in range(n):
-            coord._last_keepalive = 0
+            coord._last_keepalive = _KEEPALIVE_FORCE
             with contextlib.suppress(Exception):
                 await coord._async_update_data()
 

--- a/tests/test_model_identification.py
+++ b/tests/test_model_identification.py
@@ -122,6 +122,55 @@ class TestBinarySerialDecoder:
         # which the decoder guarantees to be the codice.
         assert info["digits"][:6] == "217055"
 
+    def test_binary_serial_roundtrips_into_transcode_table(self):
+        """End-to-end: decoded SKU resolves to the PrimaDonna Soul entry."""
+        table = _load_transcode_table()
+        info = DeLonghiApi.parse_serial_number(self.PRIMADONNA_SOUL_B64)
+        assert info is not None
+        match = DeLonghiApi.match_transcode_table(table, sku_digits=info["digits"][:6])
+        assert match is not None
+        assert match["appModelId"] == "PD_SOUL"
+
+    def test_invalid_calendar_date_falls_back_to_plaintext(self):
+        """Structurally valid but calendrically impossible date (Feb 31) is rejected.
+
+        Without datetime.date validation, 217055ZZ250231 1 0700 passes the
+        month<=12 / day<=31 guard and yields a bogus binary record. It must
+        instead fall back to the plaintext regex path.
+        """
+        import base64
+
+        payload = b"header\x00217055ZZ2502311" + b"0700" + b"\x00\x00\x00"
+        encoded = base64.b64encode(payload).decode("ascii")
+        info = DeLonghiApi.parse_serial_number(encoded)
+        assert info is not None
+        assert info.get("format") == "plaintext", (
+            "Feb 31 must be rejected by real-date validation, forcing plaintext fallback"
+        )
+
+    def test_binary_regex_does_not_match_outside_payload_slice(self):
+        """Payload shaped like a serial but placed outside the documented frame
+        slice (6-byte header + payload + 3-byte trailer) must not be accepted.
+
+        This guards against false positives where random bytes in a larger
+        envelope happen to match the SKU pattern.
+        """
+        import base64
+
+        # 6-byte header, NO real payload, trailer, then a decoy shaped like
+        # a serial (but the frame length is inconsistent — payload would extend
+        # past the declared trailer).
+        header = b"hdr\x01\x02\x03"
+        trailer = b"\xaa\xbb\xcc"
+        decoy = b"999999ZZ250815X1234"
+        garbage = header + trailer + decoy
+        encoded = base64.b64encode(garbage).decode("ascii")
+        info = DeLonghiApi.parse_serial_number(encoded)
+        assert info is not None
+        assert info.get("format") == "plaintext", (
+            "Decoy at wrong frame offset must not be treated as a valid binary serial"
+        )
+
 
 class TestTranscodeTableMatching:
     """Match serial/OEM model against TranscodeTable.

--- a/tests/test_model_identification.py
+++ b/tests/test_model_identification.py
@@ -49,6 +49,80 @@ class TestSerialNumberParsing:
         assert info["raw"] == "EC"
 
 
+class TestBinarySerialDecoder:
+    """Modern ECAM firmware (PrimaDonna Soul et al.) exposes d270_serialnumber
+    as base64-encoded binary: 6-byte header + 19 ASCII chars + 3-byte trailer.
+
+    The 19-char payload structure (per De'Longhi service documentation):
+        CCCCCC EE AA MM GG L PPPP
+        where C=codice, E=esecuzione, A=anno, M=mese, G=giorno,
+              L=lettera, P=produzione
+    """
+
+    # Real-world sample from @lodzen (PrimaDonna Soul, DSN AC000W040821014,
+    # production 2025-07-01). Structure: 217055 ZZ 25 07 01 3 0134.
+    PRIMADONNA_SOUL_B64 = "0BuhDwDNMjE3MDU1WloyNTA3MDEzMDEzNAD9pg=="
+
+    def test_binary_serial_extracts_sku_digits(self):
+        """Base64 binary serial exposes the first 6 SKU digits."""
+        info = DeLonghiApi.parse_serial_number(self.PRIMADONNA_SOUL_B64)
+        assert info is not None
+        assert info["digits"].startswith("217055")
+
+    def test_binary_serial_surfaces_production_date(self):
+        """Production date fields are decoded when binary envelope detected."""
+        info = DeLonghiApi.parse_serial_number(self.PRIMADONNA_SOUL_B64)
+        assert info is not None
+        assert info.get("year") == 2025
+        assert info.get("month") == 7
+        assert info.get("day") == 1
+
+    def test_binary_serial_surfaces_execution_code(self):
+        """Execution code (2 alphanumeric chars after SKU) is surfaced."""
+        info = DeLonghiApi.parse_serial_number(self.PRIMADONNA_SOUL_B64)
+        assert info is not None
+        assert info.get("execution") == "ZZ"
+
+    def test_binary_serial_surfaces_production_sequence(self):
+        """Production sequence (last 4 digits) is surfaced for uniqueness."""
+        info = DeLonghiApi.parse_serial_number(self.PRIMADONNA_SOUL_B64)
+        assert info is not None
+        assert info.get("production") == "0134"
+
+    def test_binary_serial_preserves_raw(self):
+        """Raw base64 is preserved alongside decoded fields."""
+        info = DeLonghiApi.parse_serial_number(self.PRIMADONNA_SOUL_B64)
+        assert info is not None
+        assert info["raw"] == self.PRIMADONNA_SOUL_B64
+
+    def test_binary_serial_marks_format(self):
+        """Binary-decoded samples expose format='binary' for downstream logic."""
+        info = DeLonghiApi.parse_serial_number(self.PRIMADONNA_SOUL_B64)
+        assert info is not None
+        assert info.get("format") == "binary"
+
+    def test_plaintext_fallback_marks_format(self):
+        """Legacy plaintext serials expose format='plaintext'."""
+        info = DeLonghiApi.parse_serial_number("ECAM61075MB12345")
+        assert info is not None
+        assert info.get("format") == "plaintext"
+
+    def test_invalid_base64_falls_back_to_regex(self):
+        """Non-b64 garbage still yields best-effort digit extraction."""
+        info = DeLonghiApi.parse_serial_number("!!!garbage!!!XY42Z")
+        assert info is not None
+        assert info.get("format") == "plaintext"
+        assert info["digits"] == "42"
+
+    def test_binary_serial_matches_transcode_table(self):
+        """Decoded SKU digits feed directly into match_transcode_table."""
+        info = DeLonghiApi.parse_serial_number(self.PRIMADONNA_SOUL_B64)
+        assert info is not None
+        # The match_transcode_table call uses the first 6 digits of `digits`,
+        # which the decoder guarantees to be the codice.
+        assert info["digits"][:6] == "217055"
+
+
 class TestTranscodeTableMatching:
     """Match serial/OEM model against TranscodeTable.
 


### PR DESCRIPTION
## Summary

Decodes the **base64-framed binary** `d270_serialnumber` envelope used by PrimaDonna Soul and other recent ECAM firmware, so the TranscodeTable now matches on SKU instead of silently falling through to `OEM_TO_APP_MODEL` — which in turn was missing entries like `DL-millcore` (lodzen's machine).

Layout (per the De'Longhi service sticker image shared by @MattG-K in #6):

```
[6-byte header]  CCCCCC EE AA MM GG L PPPP  [3-byte trailer]
                 └codice └esec └yr └mo └dy └ltr └production
```

Real-world sample validated end-to-end: `0BuhDwDNMjE3MDU1WloyNTA3MDEzMDEzNAD9pg==` (lodzen, DSN `AC000W040821014`, production 2025-07-01) → SKU `217055` → matches `PD_SOUL` in TranscodeTable directly.

## Behaviour

- Base64 with well-formed inner structure → `format: binary`, structured fields (`sku`, `execution`, `year`, `month`, `day`, `letter`, `production`) + concatenated `digits` suitable for `match_transcode_table`.
- Anything else (short plaintext like `ECAM…`, non-b64 garbage, date fields out of range) → `format: plaintext`, legacy regex extraction. Existing Eletta / Dinamica paths unaffected.

## Tests

- `TestBinarySerialDecoder` — 9 new tests: digit extraction, production date, execution code, production sequence, format tag, plaintext fallback, invalid-base64 fallback, TranscodeTable round-trip, raw preservation.
- Full suite: **773 pass** (from 764). Ruff clean.

## Test plan

- [ ] Check logs on a PrimaDonna Soul install show `identify_model` landing on `PD_SOUL` through SKU match (not OEM fallback)
- [ ] Verify Eletta Explore still identifies correctly via plaintext serial
- [ ] Spot-check debug log shows `format=binary` for PrimaDonna Soul, `format=plaintext` for Eletta

Refs: #6, #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced serial number parsing to support both binary and plaintext encoding formats
  * Binary-encoded serials now return detailed structured information including SKU, execution date components, and production data
  * Added automatic format detection to identify the encoding type used

<!-- end of auto-generated comment: release notes by coderabbit.ai -->