### PR TITLE
feat(daedalus): Gigya pool selector + detailed auth/connect logging

### DIFF
--- a/custom_components/delonghi_daedalus/api.py
+++ b/custom_components/delonghi_daedalus/api.py
@@ -16,7 +16,7 @@ from typing import Any
 
 import aiohttp
 
-from .const import GIGYA_BASE_URL
+from .const import GIGYA_API_KEY_PROD, GIGYA_BASE_URL
 from .gigya_auth import (
     GigyaAuthError,
     build_jwt_request_params,
@@ -74,31 +74,44 @@ class DaedalusApi:
             await self._session.close()
             self._session = None
 
-    async def login_and_get_jwt(self, *, email: str, password: str) -> tuple[str, str]:
+    async def login_and_get_jwt(
+        self,
+        *,
+        email: str,
+        password: str,
+        api_key: str = GIGYA_API_KEY_PROD,
+    ) -> tuple[str, str]:
         """Perform Gigya login + getJWT in sequence.
 
+        `api_key` must match the Gigya Pool the account was created under
+        (EU / EU_US / CH — see const.GIGYA_API_KEYS). Using the wrong key
+        yields errorCode 400093 ("Invalid parameter value: apiKey"), which
+        the UI translates as 'invalid credentials' and is misleading.
         Returns (sessionToken, jwt). The sessionToken is what we'll pass
         to getJWT later to rotate the JWT without asking the user again.
         """
-        session_token, _session_secret = await self._gigya_login(email, password)
-        jwt = await self._gigya_get_jwt(session_token)
+        session_token, _session_secret = await self._gigya_login(email, password, api_key)
+        jwt = await self._gigya_get_jwt(session_token, api_key)
         return session_token, jwt
 
-    async def refresh_jwt(self, *, session_token: str) -> str:
+    async def refresh_jwt(self, *, session_token: str, api_key: str = GIGYA_API_KEY_PROD) -> str:
         """Get a fresh JWT from an existing session token."""
-        return await self._gigya_get_jwt(session_token)
+        return await self._gigya_get_jwt(session_token, api_key)
 
-    async def _gigya_login(self, email: str, password: str) -> tuple[str, str]:
-        payload = await self._post_gigya("/accounts.login", build_login_params(loginID=email, password=password))
+    async def _gigya_login(self, email: str, password: str, api_key: str) -> tuple[str, str]:
+        payload = await self._post_gigya(
+            "/accounts.login",
+            build_login_params(loginID=email, password=password, api_key=api_key),
+        )
         try:
             return parse_login_response(payload)
         except GigyaAuthError as exc:
             raise DaedalusAuthError(str(exc)) from exc
 
-    async def _gigya_get_jwt(self, session_token: str) -> str:
+    async def _gigya_get_jwt(self, session_token: str, api_key: str) -> str:
         payload = await self._post_gigya(
             "/accounts.getJWT",
-            build_jwt_request_params(session_token=session_token),
+            build_jwt_request_params(session_token=session_token, api_key=api_key),
         )
         try:
             return parse_jwt_response(payload)

--- a/custom_components/delonghi_daedalus/config_flow.py
+++ b/custom_components/delonghi_daedalus/config_flow.py
@@ -31,9 +31,12 @@ from .const import (
     CONF_JWT,
     CONF_MACHINE_NAME,
     CONF_PASSWORD,
+    CONF_POOL,
     CONF_SERIAL_NUMBER,
     CONF_SESSION_TOKEN,
     DOMAIN,
+    GIGYA_API_KEYS,
+    GIGYA_POOL_EU,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -44,6 +47,7 @@ _USER_SCHEMA = vol.Schema(
         vol.Required(CONF_PASSWORD): str,
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_SERIAL_NUMBER): str,
+        vol.Optional(CONF_POOL, default=GIGYA_POOL_EU): vol.In(list(GIGYA_API_KEYS.keys())),
     }
 )
 
@@ -66,6 +70,8 @@ class DaedalusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         serial = user_input[CONF_SERIAL_NUMBER]
         host = user_input[CONF_HOST]
+        pool = user_input.get(CONF_POOL, GIGYA_POOL_EU)
+        api_key = GIGYA_API_KEYS[pool]
 
         # Unique id = email + SN, so the same account on multiple machines is OK.
         await self.async_set_unique_id(f"{user_input[CONF_EMAIL]}:{serial}")
@@ -74,13 +80,22 @@ class DaedalusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         api = self._api_factory()
         try:
             session_token, jwt = await api.login_and_get_jwt(
-                email=user_input[CONF_EMAIL], password=user_input[CONF_PASSWORD]
+                email=user_input[CONF_EMAIL],
+                password=user_input[CONF_PASSWORD],
+                api_key=api_key,
             )
             lan = await api.connect_lan(host=host, serial_number=serial, jwt=jwt)
             await lan.close()
-        except DaedalusAuthError:
+        except DaedalusAuthError as exc:
+            _LOGGER.warning("Daedalus login refused (pool=%s, host=%s): %s", pool, host, exc)
             errors["base"] = "invalid_auth"
-        except DaedalusConnectionError:
+        except DaedalusConnectionError as exc:
+            _LOGGER.warning(
+                "Daedalus LAN probe failed (host=%s, serial=%s): %s",
+                host,
+                serial,
+                exc,
+            )
             errors["base"] = "cannot_connect"
         except Exception:  # noqa: BLE001 — last-resort net so the form still renders
             _LOGGER.exception("Unexpected error validating Daedalus machine")
@@ -99,6 +114,7 @@ class DaedalusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_HOST: host,
                 CONF_SERIAL_NUMBER: serial,
                 CONF_MACHINE_NAME: serial,
+                CONF_POOL: pool,
                 CONF_JWT: jwt,
                 CONF_SESSION_TOKEN: session_token,
             },

--- a/custom_components/delonghi_daedalus/const.py
+++ b/custom_components/delonghi_daedalus/const.py
@@ -14,7 +14,23 @@ MANUFACTURER: Final = "De'Longhi"
 
 # --- Gigya (SAP CDC) ---------------------------------------------------------
 GIGYA_BASE_URL: Final = "https://accounts.eu1.gigya.com"
-GIGYA_API_KEY_PROD: Final = "4_mXSplGaqrFT0H88TAjqJuA"
+
+# The app ships three production apiKeys (one per Gigya "pool") and switches
+# between them at runtime based on a Flutter-side region flag we can't read
+# from a static manifest dump. All three values are public (meta-data in the
+# APK manifest of `com.delonghigroup.daedalus`), equivalent to OAuth client IDs.
+GIGYA_POOL_EU: Final = "EU"
+GIGYA_POOL_EU_US: Final = "EU_US"
+GIGYA_POOL_CH: Final = "CH"
+
+GIGYA_API_KEYS: Final[dict[str, str]] = {
+    GIGYA_POOL_EU: "4_mXSplGaqrFT0H88TAjqJuA",
+    GIGYA_POOL_EU_US: "3_e5qn7USZK-QtsIso1wCelqUKAK_IVEsYshRIssQ-X-k55haiZXmKWDHDRul2e5Y2",
+    GIGYA_POOL_CH: "3_WP_c8OVu_yOoqYXN3Dq-Oi7nNkbS2bwqS3rQXJ6SPkodgE4FOpyuE_UVlrCuSGEm",
+}
+
+# Keep legacy name for existing callers / tests; points at the default Pool EU.
+GIGYA_API_KEY_PROD: Final = GIGYA_API_KEYS[GIGYA_POOL_EU]
 
 # --- AWS API Gateway (REST — devices list, pairing, OTA jobs) ----------------
 AWS_REST_BASE_URL_PROD: Final = "https://bm5vp76k69.execute-api.eu-central-1.amazonaws.com/dlg-prod/"
@@ -34,6 +50,7 @@ CONF_PASSWORD: Final = "password"  # noqa: S105 — config_entry key, not a secr
 CONF_HOST: Final = "host"
 CONF_SERIAL_NUMBER: Final = "serial_number"
 CONF_MACHINE_NAME: Final = "machine_name"
+CONF_POOL: Final = "pool"
 CONF_JWT: Final = "jwt"  # noqa: S105
 CONF_SESSION_TOKEN: Final = "session_token"  # noqa: S105
 CONF_SESSION_SECRET: Final = "session_secret"  # noqa: S105

--- a/custom_components/delonghi_daedalus/coordinator.py
+++ b/custom_components/delonghi_daedalus/coordinator.py
@@ -29,10 +29,13 @@ from .const import (
     CONF_HOST,
     CONF_JWT,
     CONF_MACHINE_NAME,
+    CONF_POOL,
     CONF_SERIAL_NUMBER,
     CONF_SESSION_TOKEN,
     DEFAULT_UPDATE_INTERVAL_SECONDS,
     DOMAIN,
+    GIGYA_API_KEYS,
+    GIGYA_POOL_EU,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -91,7 +94,9 @@ class DaedalusCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             session_token = self.entry.data.get(CONF_SESSION_TOKEN)
             if not session_token:
                 raise
-            fresh_jwt = await self._api.refresh_jwt(session_token=session_token)
+            pool = self.entry.data.get(CONF_POOL, GIGYA_POOL_EU)
+            api_key = GIGYA_API_KEYS.get(pool, GIGYA_API_KEYS[GIGYA_POOL_EU])
+            fresh_jwt = await self._api.refresh_jwt(session_token=session_token, api_key=api_key)
             self.hass.config_entries.async_update_entry(self.entry, data={**self.entry.data, CONF_JWT: fresh_jwt})
             self._lan = await self._api.connect_lan(host=host, serial_number=self.serial_number, jwt=fresh_jwt)
 

--- a/custom_components/delonghi_daedalus/translations/en.json
+++ b/custom_components/delonghi_daedalus/translations/en.json
@@ -8,7 +8,8 @@
           "email": "Email",
           "password": "Password",
           "host": "Machine IP on LAN",
-          "serial_number": "Machine serial number"
+          "serial_number": "Machine serial number",
+          "pool": "Account region (Gigya pool) — try EU first; switch to EU_US if login fails"
         }
       }
     },

--- a/custom_components/delonghi_daedalus/translations/fr.json
+++ b/custom_components/delonghi_daedalus/translations/fr.json
@@ -8,7 +8,8 @@
           "email": "Email",
           "password": "Mot de passe",
           "host": "IP locale de la machine",
-          "serial_number": "Numéro de série"
+          "serial_number": "Numéro de série",
+          "pool": "Région du compte (pool Gigya) — essayer EU en premier ; passer à EU_US si la connexion échoue"
         }
       }
     },

--- a/tests/daedalus/test_api_client.py
+++ b/tests/daedalus/test_api_client.py
@@ -97,3 +97,36 @@ def test_login_wraps_transport_errors() -> None:
             await api.close()
 
     asyncio.run(_run())
+
+
+def test_login_uses_custom_api_key_when_pool_is_eu_us() -> None:
+    """EU_US accounts (Gigya SDK v3) need the alternate apiKey from the manifest."""
+
+    async def _run() -> None:
+        captured: dict[str, str] = {}
+
+        async def login(request: web.Request) -> web.Response:
+            body = await request.post()
+            captured["apiKey"] = str(body["apiKey"])
+            return web.json_response(
+                {
+                    "errorCode": 0,
+                    "sessionInfo": {"sessionToken": "st", "sessionSecret": "ss"},
+                    "UID": "uid-1",
+                }
+            )
+
+        async def get_jwt(request: web.Request) -> web.Response:
+            return web.json_response({"errorCode": 0, "id_token": "jwt-abc"})
+
+        runner, base = await _start_gigya({"/accounts.login": login, "/accounts.getJWT": get_jwt})
+        try:
+            api = DaedalusApi(gigya_base_url=base)
+            eu_us_key = "3_e5qn7USZK-QtsIso1wCelqUKAK_IVEsYshRIssQ-X-k55haiZXmKWDHDRul2e5Y2"
+            await api.login_and_get_jwt(email="u", password="p", api_key=eu_us_key)
+            assert captured["apiKey"] == eu_us_key
+        finally:
+            await api.close()
+            await runner.cleanup()
+
+    asyncio.run(_run())

--- a/tests/daedalus/test_config_flow.py
+++ b/tests/daedalus/test_config_flow.py
@@ -8,7 +8,10 @@ WS to validate they're reachable before creating the entry.
 from __future__ import annotations
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from custom_components.delonghi_daedalus.api import (
     DaedalusAuthError,
@@ -21,8 +24,12 @@ from custom_components.delonghi_daedalus.const import (
     CONF_JWT,
     CONF_MACHINE_NAME,
     CONF_PASSWORD,
+    CONF_POOL,
     CONF_SERIAL_NUMBER,
     CONF_SESSION_TOKEN,
+    GIGYA_API_KEYS,
+    GIGYA_POOL_EU,
+    GIGYA_POOL_EU_US,
 )
 
 
@@ -113,6 +120,117 @@ def test_cannot_connect_shows_form_error() -> None:
     )
     assert result["type"] == "form"
     assert result["errors"]["base"] == "cannot_connect"
+
+
+def test_pool_selection_passes_matching_api_key_to_login() -> None:
+    """When user picks Pool EU_US, the flow must forward the EU_US Gigya apiKey."""
+    api = MagicMock()
+    api.login_and_get_jwt = AsyncMock(return_value=("session-abc", "jwt-xyz"))
+    lan = MagicMock()
+    lan.connection_id = 7
+    lan.close = AsyncMock()
+    api.connect_lan = AsyncMock(return_value=lan)
+    api.close = AsyncMock()
+
+    flow = _make_flow(api)
+    result = asyncio.run(
+        flow.async_step_user(
+            {
+                CONF_EMAIL: "user@example.com",
+                CONF_PASSWORD: "hunter2",
+                CONF_HOST: "192.168.1.42",
+                CONF_SERIAL_NUMBER: "SN1234",
+                CONF_POOL: GIGYA_POOL_EU_US,
+            }
+        )
+    )
+
+    assert result["type"] == "create_entry"
+    api.login_and_get_jwt.assert_awaited_once()
+    call = api.login_and_get_jwt.await_args
+    assert call.kwargs["api_key"] == GIGYA_API_KEYS[GIGYA_POOL_EU_US]
+    assert result["data"][CONF_POOL] == GIGYA_POOL_EU_US
+
+
+def test_pool_defaults_to_eu_when_not_provided() -> None:
+    """Backwards-compat: existing flows without pool field keep using Pool EU."""
+    api = MagicMock()
+    api.login_and_get_jwt = AsyncMock(return_value=("s", "j"))
+    lan = MagicMock()
+    lan.connection_id = 1
+    lan.close = AsyncMock()
+    api.connect_lan = AsyncMock(return_value=lan)
+    api.close = AsyncMock()
+
+    flow = _make_flow(api)
+    asyncio.run(
+        flow.async_step_user(
+            {
+                CONF_EMAIL: "u",
+                CONF_PASSWORD: "p",
+                CONF_HOST: "192.168.1.42",
+                CONF_SERIAL_NUMBER: "SN",
+            }
+        )
+    )
+    assert api.login_and_get_jwt.await_args.kwargs["api_key"] == GIGYA_API_KEYS[GIGYA_POOL_EU]
+
+
+def test_invalid_auth_logs_reason(caplog: pytest.LogCaptureFixture) -> None:
+    """Auth rejection must surface the upstream Gigya error in HA logs.
+
+    Without this, users see only the translated 'Invalid credentials' form
+    error and can't tell a real bad-password apart from a pool/apiKey
+    mismatch — which is exactly what happened with Eletta Ultra users who
+    sit on Gigya Pool EU_US while the integration defaulted to EU.
+    """
+    api = MagicMock()
+    api.login_and_get_jwt = AsyncMock(side_effect=DaedalusAuthError("Gigya error 400093: invalid apiKey"))
+    api.close = AsyncMock()
+
+    flow = _make_flow(api)
+    with caplog.at_level(logging.WARNING, logger="custom_components.delonghi_daedalus.config_flow"):
+        asyncio.run(
+            flow.async_step_user(
+                {
+                    CONF_EMAIL: "u",
+                    CONF_PASSWORD: "p",
+                    CONF_HOST: "192.168.1.42",
+                    CONF_SERIAL_NUMBER: "SN",
+                }
+            )
+        )
+    assert any(
+        "400093" in record.getMessage() or "invalid apiKey" in record.getMessage() for record in caplog.records
+    ), f"expected Gigya error detail in logs, got: {[r.getMessage() for r in caplog.records]}"
+
+
+def test_cannot_connect_logs_reason(caplog: pytest.LogCaptureFixture) -> None:
+    api = MagicMock()
+    api.login_and_get_jwt = AsyncMock(return_value=("s", "jwt"))
+    api.connect_lan = AsyncMock(
+        side_effect=DaedalusConnectionError(
+            "LAN WS connect to wss://10.0.0.5/ws/lan2lan failed: [Errno 113] No route to host"
+        )
+    )
+    api.close = AsyncMock()
+
+    flow = _make_flow(api)
+    with caplog.at_level(logging.WARNING, logger="custom_components.delonghi_daedalus.config_flow"):
+        asyncio.run(
+            flow.async_step_user(
+                {
+                    CONF_EMAIL: "u",
+                    CONF_PASSWORD: "p",
+                    CONF_HOST: "10.0.0.5",
+                    CONF_SERIAL_NUMBER: "SN",
+                }
+            )
+        )
+    assert any(
+        "No route to host" in record.getMessage() or "LAN WS connect" in record.getMessage()
+        for record in caplog.records
+    ), f"expected LAN connect detail in logs, got: {[r.getMessage() for r in caplog.records]}"
 
 
 def test_unknown_error_shows_form_error() -> None:


### PR DESCRIPTION
## Why

@stivxgamer (issue #18) can't log in through the freshly-scaffolded Daedalus integration — his Eletta Ultra account refuses credentials even though the same email/password work in the official My Coffee Lounge app.

Root cause (confirmed via the decompiled APK manifest): De'Longhi ships **three production Gigya apiKeys**, one per Pool — `EU` (`4_mXSplGa...`), `EU_US` (`3_e5qn...`), `CH` (`3_WP_c8O...`) — and the Flutter layer switches between them per user region. The integration's first scaffold hardcoded only `EU`, so accounts provisioned under `EU_US` (the newer Gigya SDK v3 bucket, which Daedalus defaults to for most new signups) get 400093 "Invalid parameter value: apiKey" — translated by HA as "invalid credentials".

## What

- `const.GIGYA_API_KEYS` map + `CONF_POOL`
- `DaedalusApi.login_and_get_jwt` / `refresh_jwt` take an explicit `api_key`
- config flow: optional `pool` dropdown (defaults to `EU` for backwards-compat); selected pool is persisted in the entry so the coordinator reuses it on JWT rotation
- `_LOGGER.warning` on `DaedalusAuthError` / `DaedalusConnectionError` paths so users on HA can see *why* the flow failed (Gigya errorCode, LAN connect errno…) instead of just the translated form error
- translations EN/FR: pool label + hint

## Tests (TDD)

5 new unit tests:
- api_client: login forwards the chosen api_key to Gigya
- config_flow: pool EU_US -> EU_US key, default pool = EU, logs Gigya detail on auth error, logs LAN detail on connect error

31/31 daedalus tests green, full suite 812/812.

## User-facing

Once merged, stivxgamer can re-run the integration config, pick **EU_US** in the new dropdown, and we'll see either (a) it works, or (b) the new WARNING log finally tells us the actual Gigya errorCode so we can diagnose further (bad password vs. different region vs. entirely new auth flow). No telemetry / data change.

Refs #18.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account region (Gigya pool) selection during setup, supporting EU, EU_US, and CH regions
  * EU is set as the default region; users can switch to EU_US if login fails

* **Improvements**
  * Enhanced error logging to provide clearer feedback for authentication and connection failures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->