### PR TITLE
feat(daedalus): auto-probe all Gigya pools on 403005 auth failure

### DIFF
--- a/custom_components/delonghi_daedalus/config_flow.py
+++ b/custom_components/delonghi_daedalus/config_flow.py
@@ -41,6 +41,11 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Gigya errorCode returned when the account exists but has no access to this
+# application's apiKey.  Happens when the account was registered via a
+# different Gigya site (OIDC / OAuth2 redirect) rather than direct login.
+_GIGYA_UNAUTHORIZED_USER = "403005"
+
 _USER_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_EMAIL): str,
@@ -50,6 +55,51 @@ _USER_SCHEMA = vol.Schema(
         vol.Optional(CONF_POOL, default=GIGYA_POOL_EU): vol.In(list(GIGYA_API_KEYS.keys())),
     }
 )
+
+
+async def _probe_pools(
+    api: DaedalusApi,
+    *,
+    email: str,
+    password: str,
+    preferred_pool: str,
+) -> tuple[str, str, str]:
+    """Try Gigya login across all pools, preferred pool first.
+
+    Returns (pool, session_token, jwt) for the first pool that succeeds.
+
+    If the preferred pool returns 403005 ("Unauthorized user") the remaining
+    pools are tried automatically — this covers accounts registered on a
+    different pool than EU without requiring the user to guess.
+
+    Any other auth error (wrong password, rate-limit…) short-circuits
+    immediately so we don't burn all pools on a typo.
+
+    Raises DaedalusAuthError with message starting with "all_pools:" when
+    every pool returns 403005 — the caller maps this to the dedicated
+    translation key.
+    """
+    pools_ordered = [preferred_pool] + [p for p in GIGYA_API_KEYS if p != preferred_pool]
+    last_exc: DaedalusAuthError | None = None
+
+    for pool in pools_ordered:
+        api_key = GIGYA_API_KEYS[pool]
+        try:
+            session_token, jwt = await api.login_and_get_jwt(email=email, password=password, api_key=api_key)
+            if pool != preferred_pool:
+                _LOGGER.info(
+                    "Daedalus: preferred pool %s returned 403005, succeeded with %s",
+                    preferred_pool,
+                    pool,
+                )
+            return pool, session_token, jwt
+        except DaedalusAuthError as exc:
+            last_exc = exc
+            if _GIGYA_UNAUTHORIZED_USER not in str(exc):
+                raise  # wrong password / rate-limit — no point probing other pools
+            _LOGGER.debug("Daedalus: pool %s → 403005, probing next pool", pool)
+
+    raise DaedalusAuthError(f"all_pools: every Gigya pool returned 403005 for {email}") from last_exc
 
 
 class DaedalusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -70,25 +120,32 @@ class DaedalusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
         serial = user_input[CONF_SERIAL_NUMBER]
         host = user_input[CONF_HOST]
-        pool = user_input.get(CONF_POOL, GIGYA_POOL_EU)
-        api_key = GIGYA_API_KEYS[pool]
+        preferred_pool = user_input.get(CONF_POOL, GIGYA_POOL_EU)
+        resolved_pool = preferred_pool
 
         # Unique id = email + SN, so the same account on multiple machines is OK.
         await self.async_set_unique_id(f"{user_input[CONF_EMAIL]}:{serial}")
         self._abort_if_unique_id_configured()
 
         api = self._api_factory()
+        session_token = jwt = ""
         try:
-            session_token, jwt = await api.login_and_get_jwt(
+            resolved_pool, session_token, jwt = await _probe_pools(
+                api,
                 email=user_input[CONF_EMAIL],
                 password=user_input[CONF_PASSWORD],
-                api_key=api_key,
+                preferred_pool=preferred_pool,
             )
             lan = await api.connect_lan(host=host, serial_number=serial, jwt=jwt)
             await lan.close()
         except DaedalusAuthError as exc:
-            _LOGGER.warning("Daedalus login refused (pool=%s, host=%s): %s", pool, host, exc)
-            errors["base"] = "invalid_auth"
+            _LOGGER.warning(
+                "Daedalus login refused (preferred_pool=%s, host=%s): %s",
+                preferred_pool,
+                host,
+                exc,
+            )
+            errors["base"] = "all_pools_unauthorized" if str(exc).startswith("all_pools:") else "invalid_auth"
         except DaedalusConnectionError as exc:
             _LOGGER.warning(
                 "Daedalus LAN probe failed (host=%s, serial=%s): %s",
@@ -114,7 +171,7 @@ class DaedalusConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 CONF_HOST: host,
                 CONF_SERIAL_NUMBER: serial,
                 CONF_MACHINE_NAME: serial,
-                CONF_POOL: pool,
+                CONF_POOL: resolved_pool,
                 CONF_JWT: jwt,
                 CONF_SESSION_TOKEN: session_token,
             },

--- a/custom_components/delonghi_daedalus/translations/en.json
+++ b/custom_components/delonghi_daedalus/translations/en.json
@@ -9,12 +9,13 @@
           "password": "Password",
           "host": "Machine IP on LAN",
           "serial_number": "Machine serial number",
-          "pool": "Account region (Gigya pool) — try EU first; switch to EU_US if login fails"
+          "pool": "Account region (Gigya pool) — the integration auto-probes all regions, leave on EU unless you know otherwise"
         }
       }
     },
     "error": {
       "invalid_auth": "Invalid My Coffee Lounge credentials",
+      "all_pools_unauthorized": "Login failed on all account regions (EU, EU_US, CH). Your account may have been created via the in-app registration page (OAuth2/OIDC), which uses a different authentication path than direct login. Check that your password is correct, then open an issue on the integration's GitHub repository for further investigation.",
       "cannot_connect": "Cannot reach the machine on the LAN",
       "invalid_host": "Invalid IP / hostname",
       "unknown": "Unexpected error"

--- a/custom_components/delonghi_daedalus/translations/fr.json
+++ b/custom_components/delonghi_daedalus/translations/fr.json
@@ -9,12 +9,13 @@
           "password": "Mot de passe",
           "host": "IP locale de la machine",
           "serial_number": "Numéro de série",
-          "pool": "Région du compte (pool Gigya) — essayer EU en premier ; passer à EU_US si la connexion échoue"
+          "pool": "Région du compte (pool Gigya) — l'intégration sonde automatiquement toutes les régions, laisser EU sauf si vous savez"
         }
       }
     },
     "error": {
       "invalid_auth": "Identifiants My Coffee Lounge invalides",
+      "all_pools_unauthorized": "Connexion échouée sur toutes les régions (EU, EU_US, CH). Votre compte a peut-être été créé via la page d'inscription intégrée à l'app (OAuth2/OIDC), qui utilise un chemin d'authentification différent du login direct. Vérifiez votre mot de passe, puis ouvrez une issue sur le dépôt GitHub de l'intégration pour investigation.",
       "cannot_connect": "Impossible de joindre la machine sur le réseau local",
       "invalid_host": "IP ou nom d'hôte invalide",
       "unknown": "Erreur inattendue"


### PR DESCRIPTION
## Summary

- When Gigya returns **403005** ("Unauthorized user") for the selected pool, the config flow now **silently retries all remaining pools** (EU → EU_US → CH and permutations) before surfacing an error — no more manual pool-guessing.
- Any other auth error (wrong password = 403042, invalid key = 400093, rate-limit = 403120…) **short-circuits immediately** so we don't burn API calls on a typo.
- If every pool returns 403005, a dedicated `all_pools_unauthorized` error is shown — explains that the account is likely OIDC/OAuth2-registered and points the user toward opening an issue for investigation (rather than endlessly switching pools).
- Pool field hint updated: "the integration auto-probes all regions, leave on EU unless you know otherwise".

## Context

Opened following @stivxgamer's report in #18: their Eletta Ultra account returns 403005 on both EU and EU_US. This PR ensures future users hit the right error message in one attempt instead of two, and locks in the correct pool in `config_entry.data` when auto-probe succeeds.

## Test plan

- [ ] 812 existing tests pass (no daedalus config-flow tests yet — those come in a follow-up once we have a confirmed auth path from the MITM capture)
- [ ] Ruff clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integration now automatically probes all Gigya account regions (EU, EU_US, CH) instead of requiring manual selection.

* **Improvements**
  * Enhanced error messaging when authentication fails across all regions.
  * Updated configuration help text to clarify auto-probing behavior.

* **Documentation**
  * Updated English and French translations for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->